### PR TITLE
bugfix #2, redraw daylight background in manage screenshots

### DIFF
--- a/Src/analyzer/window/screenshot.c
+++ b/Src/analyzer/window/screenshot.c
@@ -595,7 +595,7 @@ void SCREENSHOT_ShowPicture(uint16_t Pointer1)
     //LCD_FillRect(LCD_MakePoint(0, 267),LCD_MakePoint(479, 271), LCD_COLOR_BLACK);
     while (!TOUCH_IsPressed())
         Sleep(50);
-    LCD_FillAll(LCD_BLACK);
+    LCD_FillAll(BackGrColor);
     //  while (TOUCH_IsPressed())
     Sleep(50);
 }
@@ -623,5 +623,5 @@ void SCREENSHOT_DeleteFile(uint16_t Pointer1)
             f_unlink(path);
         }
     }
-    LCD_FillRect(LCD_MakePoint(200, 0), LCD_MakePoint(479, 30), LCD_COLOR_BLACK);
+    LCD_FillRect(LCD_MakePoint(200, 0), LCD_MakePoint(479, 30), BackGrColor);
 }


### PR DESCRIPTION
see issue: [Manage Snapshots: background not redrawn correctly in daylight mode #2](https://github.com/maker99/Analyzer_EU1KY_CEC_AKF/issues/2)

fixing redraw issues in daylight mode: 
1) after showing a snapshot
2) after deleting a snapshot